### PR TITLE
Fix/27318 widget re rendering will cause di to fail

### DIFF
--- a/lib/v1/controller/ebbot_api_controller.dart
+++ b/lib/v1/controller/ebbot_api_controller.dart
@@ -1,15 +1,18 @@
 import 'package:ebbot_dart_client/ebbot_dart_client.dart';
 import 'package:ebbot_flutter_ui/v1/ebbot_flutter_ui.dart';
+import 'package:ebbot_flutter_ui/v1/src/initializer/service_locator.dart';
 import 'package:ebbot_flutter_ui/v1/src/service/ebbot_dart_client_service.dart';
 import 'package:get_it/get_it.dart';
 
 class EbbotApiController extends AbstractEbbotApiController {
   EbbotFlutterUiState? _ebbotFlutterUiState;
+  final ServiceLocator _serviceLocator = ServiceLocator();
 
   final String _ebbotClientServiceNotInitializedMessage =
       "EbbotClientService is not initialized";
 
-  EbbotDartClient get _client => GetIt.I.get<EbbotDartClientService>().client;
+  EbbotDartClient get _client =>
+      _serviceLocator.getService<EbbotDartClientService>().client;
 
   void attach(EbbotFlutterUiState ebbotFlutterUiState) {
     _ebbotFlutterUiState = ebbotFlutterUiState;

--- a/lib/v1/src/controller/chat_input_controller.dart
+++ b/lib/v1/src/controller/chat_input_controller.dart
@@ -1,23 +1,23 @@
 import 'package:ebbot_flutter_ui/v1/configuration/ebbot_behaviour.dart';
 import 'package:ebbot_flutter_ui/v1/src/controller/chat_input_field_controller.dart';
+import 'package:ebbot_flutter_ui/v1/src/initializer/service_locator.dart';
 import 'package:ebbot_flutter_ui/v1/src/service/log_service.dart';
 import 'package:flutter_chat_ui/flutter_chat_ui.dart';
-import 'package:get_it/get_it.dart';
 
 class ChatInputController {
   bool enabled;
   EbbotBehaviourInputEnterPressed enterPressedBehaviour;
   Function(String) onTextChanged;
   late ChatInputFieldController chatInputFieldController;
-
-  final logger = GetIt.I.get<LogService>().logger;
+  final _serviceLocator = ServiceLocator();
+  get _logger => _serviceLocator.getService<LogService>().logger;
 
   ChatInputController({
     required this.enabled,
     required this.enterPressedBehaviour,
     required this.onTextChanged,
   }) {
-    logger?.i("ChatInputController initialized with enabled: $enabled, "
+    _logger?.i("ChatInputController initialized with enabled: $enabled, "
         "enterPressedBehaviour: $enterPressedBehaviour");
 
     _initializeController();
@@ -43,22 +43,22 @@ class ChatInputController {
 
   void _handleOnTextChanged(String text) {
     if (text.isEmpty) {
-      logger?.i("text is empty, so skipping..");
+      _logger?.i("text is empty, so skipping..");
       return;
     }
 
     if (enterPressedBehaviour != EbbotBehaviourInputEnterPressed.sendMessage) {
-      logger
+      _logger
           ?.i("enterPressedBehaviour is $enterPressedBehaviour, so skipping..");
       return;
     }
 
     if (!text.endsWith('\n')) {
-      logger?.i("text does not end with newline, so skipping..");
+      _logger?.i("text does not end with newline, so skipping..");
       return;
     }
 
-    logger?.i("text does end with newline, so sending..");
+    _logger?.i("text does end with newline, so sending..");
     text = text.substring(0, text.length - 1);
 
     onTextChanged(text);

--- a/lib/v1/src/controller/chat_input_field_controller.dart
+++ b/lib/v1/src/controller/chat_input_field_controller.dart
@@ -1,12 +1,9 @@
-import 'package:ebbot_flutter_ui/v1/src/service/log_service.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_chat_ui/flutter_chat_ui.dart';
-import 'package:get_it/get_it.dart';
 
 class ChatInputFieldController extends InputTextFieldController {
   final TextEditingController _controller = TextEditingController();
   bool isDisposed = false;
-  final logger = GetIt.I.get<LogService>().logger;
 
   TextEditingController get controller => _controller;
 

--- a/lib/v1/src/controller/chat_transcript_controller.dart
+++ b/lib/v1/src/controller/chat_transcript_controller.dart
@@ -2,15 +2,12 @@ import 'dart:async';
 
 import 'package:ebbot_dart_client/entity/message/message.dart';
 import 'package:ebbot_flutter_ui/v1/src/controller/resettable_controller.dart';
+import 'package:ebbot_flutter_ui/v1/src/initializer/service_locator.dart';
 import 'package:ebbot_flutter_ui/v1/src/service/chat_transcript_service.dart';
 import 'package:ebbot_flutter_ui/v1/src/service/ebbot_chat_listener_service.dart';
-import 'package:get_it/get_it.dart';
 
 class ChatTranscriptController extends ResettableController {
-  final EbbotChatListenerService _chatListenerService =
-      GetIt.I.get<EbbotChatListenerService>();
-  final ChatTranscriptService _chatTranscriptService =
-      GetIt.I.get<ChatTranscriptService>();
+  final _serviceLocator = ServiceLocator();
 
   StreamSubscription<Message>? _messageStreamSubscription;
 
@@ -19,7 +16,7 @@ class ChatTranscriptController extends ResettableController {
   }
 
   void _handle(Message message) {
-    _chatTranscriptService.save(message);
+    _serviceLocator.getService<ChatTranscriptService>().save(message);
   }
 
   void startListening() {
@@ -27,15 +24,17 @@ class ChatTranscriptController extends ResettableController {
       _messageStreamSubscription?.cancel();
     }
 
-    _messageStreamSubscription =
-        _chatListenerService.messageStream.listen((message) {
+    final messageStream =
+        _serviceLocator.getService<EbbotChatListenerService>().messageStream;
+
+    _messageStreamSubscription = messageStream.listen((message) {
       _handle(message);
     });
   }
 
   @override
   void reset() {
-    _chatTranscriptService.reset();
+    _serviceLocator.getService<ChatTranscriptService>().reset();
     startListening();
   }
 }

--- a/lib/v1/src/controller/chat_ui_custom_message_controller.dart
+++ b/lib/v1/src/controller/chat_ui_custom_message_controller.dart
@@ -1,24 +1,20 @@
-import 'package:ebbot_dart_client/ebbot_dart_client.dart';
 import 'package:ebbot_dart_client/entity/button_data/button_data.dart';
 import 'package:ebbot_dart_client/entity/message/message.dart';
 import 'package:ebbot_flutter_ui/v1/configuration/ebbot_configuration.dart';
+import 'package:ebbot_flutter_ui/v1/src/initializer/service_locator.dart';
 import 'package:ebbot_flutter_ui/v1/src/service/ebbot_dart_client_service.dart';
-import 'package:ebbot_flutter_ui/v1/src/service/log_service.dart';
 import 'package:ebbot_flutter_ui/v1/src/widget/carousel_widget.dart';
 import 'package:ebbot_flutter_ui/v1/src/widget/rating_widget.dart';
 import 'package:ebbot_flutter_ui/v1/src/widget/url_box_widget.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_chat_types/flutter_chat_types.dart' as types;
-import 'package:get_it/get_it.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 // A controller for handling custom flutter chat ui messages
 class ChatUiCustomMessageController {
-  EbbotDartClient get client => GetIt.I.get<EbbotDartClientService>().client;
   final EbbotConfiguration configuration;
   final Function() handleRestartConversation;
-
-  final logger = GetIt.I.get<LogService>().logger;
+  final _serviceLocator = ServiceLocator();
 
   ChatUiCustomMessageController(
       {required this.configuration, required this.handleRestartConversation});
@@ -44,6 +40,7 @@ class ChatUiCustomMessageController {
   }
 
   Widget _processCarousel(MessageContent content) {
+    final client = _serviceLocator.getService<EbbotDartClientService>().client;
     return CarouselWidget(
       content: content,
       configuration: configuration,
@@ -60,6 +57,7 @@ class ChatUiCustomMessageController {
   }
 
   Widget _processRatingRequest(MessageContent content) {
+    final client = _serviceLocator.getService<EbbotDartClientService>().client;
     return RatingWidget(
       content: content,
       configuration: configuration,
@@ -70,6 +68,7 @@ class ChatUiCustomMessageController {
   }
 
   Widget _processUrl(MessageContent content) {
+    final client = _serviceLocator.getService<EbbotDartClientService>().client;
     return UrlBoxWidget(
         content: content,
         configuration: configuration,
@@ -85,6 +84,7 @@ class ChatUiCustomMessageController {
   }
 
   void _processUrlClick(String url, {ButtonData? buttonData}) async {
+    final client = _serviceLocator.getService<EbbotDartClientService>().client;
     var uri = Uri.parse(url);
 
     // This is a bit hacky, for the other types of buttons we send a message back over the websocket

--- a/lib/v1/src/controller/ebbot_chat_stream_controller.dart
+++ b/lib/v1/src/controller/ebbot_chat_stream_controller.dart
@@ -2,12 +2,12 @@ import 'dart:async';
 
 import 'package:ebbot_dart_client/entity/chat/chat.dart';
 import 'package:ebbot_flutter_ui/v1/src/controller/resettable_controller.dart';
+import 'package:ebbot_flutter_ui/v1/src/initializer/service_locator.dart';
 import 'package:ebbot_flutter_ui/v1/src/service/ebbot_chat_listener_service.dart';
-import 'package:ebbot_flutter_ui/v1/src/service/log_service.dart';
 import 'package:flutter_chat_types/flutter_chat_types.dart' as types;
-import 'package:get_it/get_it.dart';
 
 class EbbotChatStreamController extends ResettableController {
+  final _serviceLocator = ServiceLocator();
   final Function _handleTypingMessage;
   final Function _handleClearTypingUsers;
   final Function(types.Message?) _handleAddMessage;
@@ -15,9 +15,6 @@ class EbbotChatStreamController extends ResettableController {
   bool hasReceivedGPTMessageBefore = false;
 
   StreamSubscription<Chat>? _chatStreamSubscription;
-
-  EbbotChatListenerService get _chatListenerService =>
-      GetIt.I.get<EbbotChatListenerService>();
 
   EbbotChatStreamController(
     this._handleTypingMessage,
@@ -27,8 +24,6 @@ class EbbotChatStreamController extends ResettableController {
   ) {
     startListening();
   }
-
-  final logger = GetIt.I.get<LogService>().logger;
 
   void handle(Chat message) {
     //logger?.i("handling chat");
@@ -43,7 +38,11 @@ class EbbotChatStreamController extends ResettableController {
     if (_chatStreamSubscription != null) {
       _chatStreamSubscription?.cancel();
     }
-    _chatStreamSubscription = _chatListenerService.chatStream.listen((chat) {
+
+    final chatListenerService =
+        _serviceLocator.getService<EbbotChatListenerService>();
+
+    _chatStreamSubscription = chatListenerService.chatStream.listen((chat) {
       handle(chat);
     });
     _handleCanType("visible");

--- a/lib/v1/src/controller/ebbot_message_stream_controller.dart
+++ b/lib/v1/src/controller/ebbot_message_stream_controller.dart
@@ -2,22 +2,22 @@ import 'dart:async';
 
 import 'package:ebbot_dart_client/entity/message/message.dart';
 import 'package:ebbot_flutter_ui/v1/src/controller/resettable_controller.dart';
+import 'package:ebbot_flutter_ui/v1/src/initializer/service_locator.dart';
 import 'package:ebbot_flutter_ui/v1/src/parser/ebbot_message_parser.dart';
 import 'package:ebbot_flutter_ui/v1/src/service/ebbot_chat_listener_service.dart';
 import 'package:ebbot_flutter_ui/v1/src/service/log_service.dart';
 import 'package:ebbot_flutter_ui/v1/src/util/ebbot_gpt_user.dart';
 import 'package:ebbot_flutter_ui/v1/src/util/string_util.dart';
 import 'package:flutter_chat_types/flutter_chat_types.dart' as types;
-import 'package:get_it/get_it.dart';
 
 class EbbotMessageStreamController extends ResettableController {
+  final _serviceLocator = ServiceLocator();
+  get _logger => _serviceLocator.getService<LogService>().logger;
   final Function _handleTypingUsers;
   final Function _handleClearTypingUsers;
   final Function(types.Message?) _handleAddMessage;
   final Function(String?) _handleInputMode;
   bool hasReceivedGPTMessageBefore = false;
-  EbbotChatListenerService get _chatListenerService =>
-      GetIt.I.get<EbbotChatListenerService>();
 
   final _ebbotMessageParser = EbbotMessageParser();
 
@@ -31,10 +31,9 @@ class EbbotMessageStreamController extends ResettableController {
   }
 
   StreamSubscription<Message>? _messageStreamSubscription;
-  final logger = GetIt.I.get<LogService>().logger;
 
   void _handle(Message message) {
-    logger?.i("handling message");
+    _logger?.i("handling message");
     // Handle the message
     var messageType = message.data.message.type;
 
@@ -75,8 +74,10 @@ class EbbotMessageStreamController extends ResettableController {
     if (_messageStreamSubscription != null) {
       _messageStreamSubscription?.cancel();
     }
+    final chatListenerService =
+        _serviceLocator.getService<EbbotChatListenerService>();
     _messageStreamSubscription =
-        _chatListenerService.messageStream.listen((message) {
+        chatListenerService.messageStream.listen((message) {
       _handle(message);
     });
     _handleInputMode("visible");

--- a/lib/v1/src/controller/ebbot_notification_controller.dart
+++ b/lib/v1/src/controller/ebbot_notification_controller.dart
@@ -1,22 +1,24 @@
+import 'package:ebbot_flutter_ui/v1/src/initializer/service_locator.dart';
 import 'package:ebbot_flutter_ui/v1/src/service/ebbot_notification_service.dart';
 import 'package:ebbot_flutter_ui/v1/src/service/log_service.dart';
-import 'package:get_it/get_it.dart';
 
 class EbbotNotificationController {
-  final logger = GetIt.I.get<LogService>().logger;
+  final _serviceLocator = ServiceLocator();
+  get _logger => _serviceLocator.getService<LogService>().logger;
 
   late EbbotNotificationService _notificationService;
   final Function(String title, String text) _handleNotification;
   EbbotNotificationController(this._handleNotification) {
-    _notificationService = GetIt.I.get<EbbotNotificationService>();
+    _notificationService =
+        _serviceLocator.getService<EbbotNotificationService>();
     _processNotifications();
   }
 
   void _processNotifications() {
-    logger?.d(
+    _logger?.d(
         'Processing notifications: ${_notificationService.getNotifications().length}');
     for (var notification in _notificationService.getNotifications()) {
-      logger?.d('Processing notification: ${notification.title}');
+      _logger?.d('Processing notification: ${notification.title}');
       _handleNotification(notification.title, notification.text);
     }
   }

--- a/lib/v1/src/initializer/ebbot_service_initializer.dart
+++ b/lib/v1/src/initializer/ebbot_service_initializer.dart
@@ -1,27 +1,29 @@
 import 'package:ebbot_dart_client/configuration/configuration.dart';
 import 'package:ebbot_flutter_ui/v1/configuration/ebbot_configuration.dart';
+import 'package:ebbot_flutter_ui/v1/src/initializer/service_locator.dart';
 import 'package:ebbot_flutter_ui/v1/src/service/chat_transcript_service.dart';
 import 'package:ebbot_flutter_ui/v1/src/service/ebbot_callback_service.dart';
 import 'package:ebbot_flutter_ui/v1/src/service/ebbot_chat_listener_service.dart';
 import 'package:ebbot_flutter_ui/v1/src/service/ebbot_dart_client_service.dart';
 import 'package:ebbot_flutter_ui/v1/src/service/ebbot_notification_service.dart';
 import 'package:ebbot_flutter_ui/v1/src/service/log_service.dart';
-import 'package:get_it/get_it.dart';
 
 class EbbotServiceInitializer {
   final String _botId;
   final EbbotConfiguration _ebbotConfiguration;
   final Configuration _dartClientConfiguration;
+  final ServiceLocator _serviceLocator = ServiceLocator();
 
   EbbotServiceInitializer(
       this._botId, this._ebbotConfiguration, this._dartClientConfiguration);
 
   Future<void> _registerLogService() async {
-    GetIt.I.registerSingleton<LogService>(LogService(_ebbotConfiguration));
+    _serviceLocator
+        .registerService<LogService>(LogService(_ebbotConfiguration));
   }
 
   Future<void> _registerEbbotCallBackService() async {
-    GetIt.I.registerSingleton<EbbotCallbackService>(
+    _serviceLocator.registerService<EbbotCallbackService>(
         EbbotCallbackService(_ebbotConfiguration.callback));
   }
 
@@ -30,22 +32,23 @@ class EbbotServiceInitializer {
         _botId,
         _dartClientConfiguration,
         _ebbotConfiguration.userConfiguration.userAttributes);
-    GetIt.I.registerSingleton<EbbotDartClientService>(service);
+    _serviceLocator.registerService<EbbotDartClientService>(service);
     await service.initialize();
   }
 
   Future<void> _registerEbbotNotificationService() async {
-    GetIt.I.registerSingleton<EbbotNotificationService>(
-        EbbotNotificationService());
+    _serviceLocator
+        .registerService<EbbotNotificationService>(EbbotNotificationService());
   }
 
   Future<void> _registerEbbotChatListenerService() async {
-    GetIt.I.registerSingleton<EbbotChatListenerService>(
-        EbbotChatListenerService());
+    _serviceLocator
+        .registerService<EbbotChatListenerService>(EbbotChatListenerService());
   }
 
   Future<void> _registerChatTranscriptService() async {
-    GetIt.I.registerSingleton<ChatTranscriptService>(ChatTranscriptService());
+    _serviceLocator
+        .registerService<ChatTranscriptService>(ChatTranscriptService());
   }
 
   Future<void> registerServices() async {

--- a/lib/v1/src/initializer/service_locator.dart
+++ b/lib/v1/src/initializer/service_locator.dart
@@ -1,0 +1,37 @@
+import 'package:get_it/get_it.dart';
+
+class ServiceLocator {
+  static final ServiceLocator _singleton = ServiceLocator._internal();
+
+  static final GetIt _scopedInstance = GetIt.asNewInstance();
+
+  ServiceLocator._internal();
+
+  factory ServiceLocator() => _singleton;
+
+  void registerService<T extends Object>(T service) {
+    if (!_scopedInstance.isRegistered<T>()) {
+      _scopedInstance.registerSingleton<T>(service);
+    }
+  }
+
+  void registerLazySingleton<T extends Object>(T Function() factory) {
+    if (!_scopedInstance.isRegistered<T>()) {
+      _scopedInstance.registerLazySingleton<T>(factory);
+    }
+  }
+
+  void registerFactory<T extends Object>(T Function() factory) {
+    if (!_scopedInstance.isRegistered<T>()) {
+      _scopedInstance.registerFactory<T>(factory);
+    }
+  }
+
+  T getService<T extends Object>() {
+    return _scopedInstance.get<T>();
+  }
+
+  void reset() {
+    _scopedInstance.reset();
+  }
+}

--- a/lib/v1/src/parser/ebbot_message_parser.dart
+++ b/lib/v1/src/parser/ebbot_message_parser.dart
@@ -1,13 +1,14 @@
 import 'package:ebbot_dart_client/entity/message/message.dart';
+import 'package:ebbot_flutter_ui/v1/src/initializer/service_locator.dart';
 import 'package:ebbot_flutter_ui/v1/src/service/log_service.dart';
 import 'package:flutter_chat_types/flutter_chat_types.dart' as types;
-import 'package:get_it/get_it.dart';
 
 /// A parser for processing incoming ebbot chat messages and generating corresponding types of flutter chat ui messages.
 ///
 /// This class provides methods for processing various types of messages such as text, images, files, etc.
 class EbbotMessageParser {
-  final logger = GetIt.I.get<LogService>().logger;
+  final _serviceLocator = ServiceLocator();
+  get _logger => _serviceLocator.getService<LogService>().logger;
 
   /// Parses the incoming message and returns the corresponding message type.
   ///
@@ -15,33 +16,34 @@ class EbbotMessageParser {
   /// Returns `null` if the message type is unsupported.
   types.Message? parse(Message message, types.User user, String id) {
     final messageType = message.data.message.type;
+
     switch (messageType) {
       case 'gpt':
-        logger?.i("parsing gpt message");
+        _logger?.i("parsing gpt message");
         return _parseGpt(message.data.message, user, id);
       case 'image':
-        logger?.i("parsing image message");
+        _logger?.i("parsing image message");
         return _parseImage(message.data.message, user, id);
       case 'text':
-        logger?.i("parsing text message");
+        _logger?.i("parsing text message");
         return _parseText(message.data.message, user, id);
       case 'file':
-        logger?.i("parsing file message");
+        _logger?.i("parsing file message");
         return _parseFile(message.data.message, user, id);
       case 'text_info':
-        logger?.i("parsing text info message");
+        _logger?.i("parsing text info message");
         return _parseTextInfo(message.data.message, user, id);
       case 'url':
-        logger?.i("parsing url message");
+        _logger?.i("parsing url message");
         return _parseCustom(message.data.message, user, id);
       case 'rating_request':
-        logger?.i("parsing rating request");
+        _logger?.i("parsing rating request");
         return _parseCustom(message.data.message, user, id);
       case 'carousel':
-        logger?.i("parsing carousel message");
+        _logger?.i("parsing carousel message");
         return _parseCustom(message.data.message, user, id);
       default:
-        logger?.w("Unsupported message type: $messageType");
+        _logger?.w("Unsupported message type: $messageType");
         return null;
     }
   }
@@ -81,7 +83,7 @@ class EbbotMessageParser {
   types.Message? _parseImage(
       MessageContent message, types.User user, String id) {
     if (message.value is! Map<String, dynamic>) {
-      logger?.d(
+      _logger?.d(
           "message is NOT a map, I don't know how to process this, so skipping.. type is ${message.value.runtimeType}");
       return null;
     }
@@ -99,16 +101,16 @@ class EbbotMessageParser {
 
   types.Message? _parseText(
       MessageContent message, types.User user, String id) {
-    logger?.i("parsing text message of type");
+    _logger?.i("parsing text message of type");
 
     if (message.sender == 'user') {
-      logger?.i("message is from user, so skipping..");
+      _logger?.i("message is from user, so skipping..");
       return null;
     }
 
     var text = message.value is String ? message.value : message.value['text'];
 
-    logger?.i("message is correct type, so adding it: $text");
+    _logger?.i("message is correct type, so adding it: $text");
 
     return types.TextMessage(
       author: user,
@@ -121,9 +123,9 @@ class EbbotMessageParser {
 
   types.Message? _parseFile(
       MessageContent message, types.User user, String id) {
-    logger?.i("parsing file message");
+    _logger?.i("parsing file message");
     if (message.value is! Map<String, dynamic>) {
-      logger?.w(
+      _logger?.w(
           "message is NOT a map, I don't know how to process this, so skipping.. type is ${message.value.runtimeType}");
       return null;
     }

--- a/lib/v1/src/service/chat_transcript_service.dart
+++ b/lib/v1/src/service/chat_transcript_service.dart
@@ -1,11 +1,12 @@
 import 'package:ebbot_dart_client/entity/message/message.dart';
+import 'package:ebbot_flutter_ui/v1/src/initializer/service_locator.dart';
 import 'package:ebbot_flutter_ui/v1/src/service/log_service.dart';
-import 'package:get_it/get_it.dart';
 
 typedef MessageParserResolver = String? Function(MessageContent);
 
 class ChatTranscriptService {
-  final logger = GetIt.I.get<LogService>().logger;
+  final _serviceLocator = ServiceLocator();
+  get _logger => _serviceLocator.getService<LogService>().logger;
 
   final Map<double, String> _chatTranscript = {};
 
@@ -22,51 +23,52 @@ class ChatTranscriptService {
 
   void save(Message message) {
     final messageType = message.data.message.type;
+
     String? parsedMessage;
     switch (messageType) {
       case 'gpt':
-        logger?.i("Parsing GPT message");
+        _logger?.i("Parsing GPT message");
         parsedMessage = _composeMessage(message, _parseGpt);
         break;
       case 'image':
-        logger?.i("Parsing image message");
+        _logger?.i("Parsing image message");
         parsedMessage = _composeMessage(message, _parseImage);
         break;
       case 'text':
-        logger?.i("Parsing text message");
+        _logger?.i("Parsing text message");
         parsedMessage = _composeMessage(message, _parseText);
         break;
       case 'file':
-        logger?.i("Parsing file message");
+        _logger?.i("Parsing file message");
         parsedMessage = _composeMessage(message, _parseFile);
         break;
       case 'text_info':
-        logger?.i("Parsing text info message");
+        _logger?.i("Parsing text info message");
         parsedMessage = _composeMessage(message, _parseTextInfo);
         break;
       case 'url':
-        logger?.i("Parsing URL message");
+        _logger?.i("Parsing URL message");
         parsedMessage = _composeMessage(message, _parseUrl);
         break;
       case 'rating_request':
-        logger?.i("Parsing rating request message");
+        _logger?.i("Parsing rating request message");
         parsedMessage = _composeMessage(message, _parseRatingRequest);
         break;
       case 'carousel':
-        logger?.i("Parsing carousel message");
+        _logger?.i("Parsing carousel message");
         parsedMessage = _composeMessage(message, _parseCarousel);
         break;
       // Feedback types
       case 'button_click':
-        logger?.i("Parsing button click message");
+        _logger?.i("Parsing button click message");
         parsedMessage = _composeMessage(message, _parseButtonClick);
         break;
       case 'rating':
-        logger?.i("Parsing rating message");
+        _logger?.i("Parsing rating message");
         parsedMessage = _composeMessage(message, _getRating);
         break;
       default:
-        logger?.w("Unsupported message type: $messageType");
+        _logger?.w("Unsupported message type: $messageType");
         break;
     }
 
@@ -84,8 +86,9 @@ class ChatTranscriptService {
   }
 
   String? _parseImage(MessageContent content) {
+
     if (content.value is! Map<String, dynamic>) {
-      logger?.i(
+      _logger?.i(
           "message is NOT a map, I don't know how to process this, so skipping.. type is ${content.value.runtimeType}");
       return null;
     }
@@ -102,8 +105,9 @@ class ChatTranscriptService {
   }
 
   String _parseFile(MessageContent content) {
+
     if (content.value is! Map<String, dynamic>) {
-      logger?.w('value is not a map');
+      _logger?.w('value is not a map');
       return '';
     }
     Map<String, dynamic> file = content.value;
@@ -117,8 +121,9 @@ class ChatTranscriptService {
   }
 
   String _parseUrl(MessageContent content) {
+
     if (content.value['urls'] is! List) {
-      logger?.w('URLs is not a list');
+      _logger?.w('URLs is not a list');
       return '';
     }
 
@@ -139,8 +144,9 @@ class ChatTranscriptService {
   }
 
   String _parseCarousel(MessageContent content) {
+
     if (content.value['slides'] is! List) {
-      logger?.w('Carousel slides is not a list');
+      _logger?.w('Carousel slides is not a list');
       return '';
     }
 
@@ -168,14 +174,16 @@ class ChatTranscriptService {
   }
 
   String _getRating(MessageContent content) {
-    logger?.d(content.value);
+
+    _logger?.d(content.value);
 
     final rating = content.value['rating'];
     return rating.toString();
   }
 
   String _parseButtonClick(MessageContent content) {
-    logger?.d(content.toJson());
+
+    _logger?.d(content.toJson());
 
     return content.value;
   }
@@ -193,6 +201,7 @@ class ChatTranscriptService {
   }
 
   String _getSubHeader(Message message) {
+
     try {
       final int timestamp =
           parseTimestampToMillis(message.data.message.timestamp);
@@ -211,7 +220,7 @@ class ChatTranscriptService {
 
       return '$formattedTime $author';
     } catch (e) {
-      logger?.e('Error parsing timestamp: $e');
+      _logger?.e('Error parsing timestamp: $e');
       return "";
     }
   }

--- a/lib/v1/src/service/ebbot_chat_listener_service.dart
+++ b/lib/v1/src/service/ebbot_chat_listener_service.dart
@@ -1,13 +1,14 @@
 import 'package:ebbot_dart_client/entity/chat/chat.dart';
 import 'package:ebbot_dart_client/entity/message/message.dart';
+import 'package:ebbot_flutter_ui/v1/src/initializer/service_locator.dart';
 import 'package:ebbot_flutter_ui/v1/src/service/ebbot_dart_client_service.dart';
-import 'package:get_it/get_it.dart';
 
 class EbbotChatListenerService {
-  EbbotDartClientService get _clientService =>
-      GetIt.I.get<EbbotDartClientService>();
+  final _serviceLocator = ServiceLocator();
 
-  Stream<Chat> get chatStream => _clientService.client.chatStream;
+  Stream<Chat> get chatStream =>
+      _serviceLocator.getService<EbbotDartClientService>().client.chatStream;
 
-  Stream<Message> get messageStream => _clientService.client.messageStream;
+  Stream<Message> get messageStream =>
+      _serviceLocator.getService<EbbotDartClientService>().client.messageStream;
 }

--- a/lib/v1/src/service/ebbot_dart_client_service.dart
+++ b/lib/v1/src/service/ebbot_dart_client_service.dart
@@ -1,10 +1,11 @@
 import 'package:ebbot_dart_client/configuration/configuration.dart';
 import 'package:ebbot_dart_client/ebbot_dart_client.dart';
 import 'package:ebbot_flutter_ui/v1/configuration/ebbot_callback.dart';
+import 'package:ebbot_flutter_ui/v1/src/initializer/service_locator.dart';
 import 'package:ebbot_flutter_ui/v1/src/service/ebbot_callback_service.dart';
-import 'package:get_it/get_it.dart';
 
 class EbbotDartClientService {
+  final _serviceLocator = ServiceLocator();
   final String _botId;
   final Configuration _configuration;
   final Map<String, dynamic> _userAttributes;
@@ -36,7 +37,7 @@ class EbbotDartClientService {
   }
 
   Future<void> initialize() async {
-    final callbackService = GetIt.I.get<EbbotCallbackService>();
+    final callbackService = _serviceLocator.getService<EbbotCallbackService>();
     try {
       await _client.initialize();
     } catch (e, stackTrace) {

--- a/lib/v1/src/service/ebbot_notification_service.dart
+++ b/lib/v1/src/service/ebbot_notification_service.dart
@@ -1,14 +1,15 @@
 import 'package:ebbot_dart_client/entity/notification/notification.dart';
+import 'package:ebbot_flutter_ui/v1/src/initializer/service_locator.dart';
 import 'package:ebbot_flutter_ui/v1/src/service/ebbot_dart_client_service.dart';
 import 'package:ebbot_flutter_ui/v1/src/service/log_service.dart';
-import 'package:get_it/get_it.dart';
 
 class EbbotNotificationService {
-  final logger = GetIt.I.get<LogService>().logger;
+  final _serviceLocator = ServiceLocator();
+  get _logger => _serviceLocator.getService<LogService>().logger;
 
   List<Notification> getNotifications() {
-    logger?.d('Getting notifications');
-    final client = GetIt.I.get<EbbotDartClientService>().client;
+    final client = _serviceLocator.getService<EbbotDartClientService>().client;
+    _logger?.d('Getting notifications');
     return client.notifications;
   }
 }

--- a/lib/v1/src/widget/carousel_widget.dart
+++ b/lib/v1/src/widget/carousel_widget.dart
@@ -1,6 +1,7 @@
 import 'package:ebbot_dart_client/entity/button_data/button_data.dart';
 import 'package:ebbot_dart_client/entity/message/message.dart';
 import 'package:ebbot_flutter_ui/v1/configuration/ebbot_configuration.dart';
+import 'package:ebbot_flutter_ui/v1/src/initializer/service_locator.dart';
 import 'package:ebbot_flutter_ui/v1/src/service/log_service.dart';
 import 'package:ebbot_flutter_ui/v1/src/widget/url_button_widget.dart';
 import 'package:flutter/material.dart';
@@ -31,11 +32,11 @@ class _CarouselWidgetState extends State<CarouselWidget> {
   final PageController _controller = PageController(initialPage: 0);
   int _currentPage = 0;
 
-  final logger = GetIt.I.get<LogService>().logger;
-
+  final _serviceLocator = ServiceLocator();
+  get _logger => _serviceLocator.getService<LogService>().logger;
   @override
   Widget build(BuildContext context) {
-    logger?.i("Building carousel, page: $_currentPage");
+    _logger?.i("Building carousel, page: $_currentPage");
     final content = widget.content;
 
     if (content.value['slides'] is! List) {
@@ -50,7 +51,7 @@ class _CarouselWidgetState extends State<CarouselWidget> {
           itemCount: slides.length,
           controller: _controller,
           onPageChanged: (int page) {
-            logger?.i("Page changed to $page, current page: $_currentPage");
+            _logger?.i("Page changed to $page, current page: $_currentPage");
             setState(() {
               _currentPage = page;
             });


### PR DESCRIPTION
Is solution provides a fix for this issue provided by one of our customers:
![image](https://github.com/user-attachments/assets/1381db78-ef68-4b29-9207-200272500bbd)

The issue arises when the widget is disposed and then re-rendered, any objects registered with GetIt will then be registered a second time, yielding this exception.

The solution is to refactor out GetIt to a separate class (`ServiceLocator`) that provides a scoped instance for `GetIt`. This is a good idea overall, as we should not use the global GetIt state, as it might interfere with existing implementations upstream